### PR TITLE
Changed hugepages allocation to 4Gb for fix in running on k8s

### DIFF
--- a/python/fddaqconf/apps/readout_gen.py
+++ b/python/fddaqconf/apps/readout_gen.py
@@ -460,7 +460,7 @@ class FDReadoutAppGenerator(ReadoutAppGenerator):
 
             readout_app.resources = {
                 "intel.com/intel_sriov_dpdk": "1", # requesting sriov
-                "hugepages-2Mi": "8Gi", # required  to allow hp allocation in k8s
+                "hugepages-2Mi": "4Gi", # required  to allow hp allocation in k8s
                 "memory": "96Gi" # required by k8s when hugepages are requested
             }
 


### PR DESCRIPTION
The  `runp04srv021eth0` pod was requesting 8Gb but the `np04-srv-021` node on kubernetes only had 4Gb allocated for HugePages. Spoke to Alessandro and he suggested we change the file configuration so it only requests 4Gb from all nodes. 