### PR TITLE
Source the RTE before pinning the thread

### DIFF
--- a/python/fddaqconf/thread_pinning.py
+++ b/python/fddaqconf/thread_pinning.py
@@ -1,5 +1,5 @@
 
-def add_thread_pinning_to_boot(system_data, thread_pinning_file, path):
+def add_thread_pinning_to_boot(system_data, thread_pinning_file, path, rte):
     after = thread_pinning_file['after']
     file  = thread_pinning_file['file']
     from pathlib import Path
@@ -33,11 +33,12 @@ def add_thread_pinning_to_boot(system_data, thread_pinning_file, path):
     system_data['boot']['scripts'][key] = {
         "after": after,
         "cmd": [
+            f"source {rte}",
             "readout-affinity.py --pinfile ${DUNEDAQ_THREAD_PIN_FILE}"
         ],
         "env": {
             "DUNEDAQ_THREAD_PIN_FILE": resolved_thread_pinning_file.resolve().as_posix(),
-            "LD_LIBRARY_PATH": "getenv",
-            "PATH": "getenv"
+            # "LD_LIBRARY_PATH": "getenv",
+            # "PATH": "getenv"
         }
     }

--- a/scripts/fddaqconf_gen
+++ b/scripts/fddaqconf_gen
@@ -624,7 +624,8 @@ def cli(
     from fddaqconf.thread_pinning import add_thread_pinning_to_boot
 
     for tpf in readout.thread_pinning_files:
-        add_thread_pinning_to_boot(system_command_datas, tpf, config_file.parent)
+        from daqconf.core.conf_utils import get_rte_script
+        add_thread_pinning_to_boot(system_command_datas, tpf, config_file.parent, get_rte_script())
 
 
     if not dry_run:


### PR DESCRIPTION
As described in the title, this PR amends the commands that are executed before executing the thread pinning. That way we ensure that the environment is the SAME as the on running the DAQ.