### PR TITLE
Exposing dpdk iface configuration parameters

### DIFF
--- a/python/fddaqconf/apps/readout_gen.py
+++ b/python/fddaqconf/apps/readout_gen.py
@@ -385,7 +385,8 @@ class FDReadoutAppGenerator(ReadoutAppGenerator):
                     f"{nic_reader_name}.output_{stream.src_id}",
                     f"datahandler_{stream.src_id}.raw_input",
                     QUEUE_FRAGMENT_TYPE,
-                    f'{FRONTEND_TYPE}_stream_{stream.src_id}', 100000
+                    ('cb_' if cfg.dpdk_enable_callback_bypass else '')+f'{FRONTEND_TYPE}_stream_{stream.src_id}',
+                    100000
                 )
             )
 

--- a/python/fddaqconf/apps/readout_gen.py
+++ b/python/fddaqconf/apps/readout_gen.py
@@ -114,8 +114,7 @@ class NICReceiverBuilder:
                     ip_addr=rx_ip,
                     mac_addr=rx_mac,
                     pci_addr=rx_pcie_dev,
-                    expected_sources=srcs,
-                    stats_reporting_cfg=nrc.StatsReporting()
+                    expected_sources=srcs
                 )
             )         
 

--- a/python/fddaqconf/apps/readout_gen.py
+++ b/python/fddaqconf/apps/readout_gen.py
@@ -72,7 +72,7 @@ class NICReceiverBuilder:
             
         return m
 
-    def build_conf(self, eal_arg_list, lcores_id_set):
+    def build_conf(self, eal_arg_list, lcores_id_set, iface_parameters):
 
 
         streams_by_if_and_tx = self.streams_by_rxiface_and_tx_endpoint()
@@ -114,7 +114,8 @@ class NICReceiverBuilder:
                     ip_addr=rx_ip,
                     mac_addr=rx_mac,
                     pci_addr=rx_pcie_dev,
-                    expected_sources=srcs
+                    expected_sources=srcs,
+                    parameters=iface_parameters
                 )
             )         
 
@@ -371,7 +372,8 @@ class FDReadoutAppGenerator(ReadoutAppGenerator):
                     plugin="NICReceiver",
                     conf=eth_ru_bldr.build_conf(
                         eal_arg_list=cfg.dpdk_eal_args,
-                        lcores_id_set=lcores_id_set
+                        lcores_id_set=lcores_id_set,
+                        iface_parameters=cfg.dpdk_iface_config
                         ),
                 )]
         

--- a/schema/fddaqconf/readoutgen.jsonnet
+++ b/schema/fddaqconf/readoutgen.jsonnet
@@ -74,8 +74,7 @@ local cs = {
     s.field( "data_files", self.data_files, default=[], doc="Files to use by detector type"),
     // DPDK
     s.field( "dpdk_eal_args", types.string, default="", doc='Args passed to the EAL in DPDK'),
-    // s.field( "dpdk_rxqueues_per_lcore", types.count, default=1, doc='Number of rx queues per core'),
-    // s.field( "dpdk_lcore_id_set", self.id_list, default=1, doc='List of IDs per core'),
+    s.field( "dpdk_iface_config", nicreader_cfg.InterfaceParameters, default=nicreader_cfg.InterfaceParameters, doc="Configuration of DPDK interface"),
     s.field( "dpdk_lcores_config", self.dpdk_lcore_config, default=self.dpdk_lcore_config, doc='Configuration of DPDK LCore IDs'),
     // FLX
     s.field( "numa_config", self.numa_config, default=self.numa_config, doc='Configuration of FELIX NUMA IDs'),

--- a/schema/fddaqconf/readoutgen.jsonnet
+++ b/schema/fddaqconf/readoutgen.jsonnet
@@ -6,6 +6,9 @@ local moo = import "moo.jsonnet";
 local stypes = import "daqconf/types.jsonnet";
 local types = moo.oschema.hier(stypes).dunedaq.daqconf.types;
 
+local snicreader = import "dpdklibs/nicreader.jsonnet";
+local nicreader_cfg = moo.oschema.hier(snicreader).dunedaq.dpdklibs.nicreader;
+
 local s = moo.oschema.schema("dunedaq.fddaqconf.readoutgen");
 local nc = moo.oschema.numeric_constraints;
 // A temporary schema construction context.
@@ -102,4 +105,4 @@ local cs = {
 
 };
 
-stypes + moo.oschema.sort_select(cs)
+stypes + snicreader + moo.oschema.sort_select(cs)

--- a/schema/fddaqconf/readoutgen.jsonnet
+++ b/schema/fddaqconf/readoutgen.jsonnet
@@ -74,6 +74,7 @@ local cs = {
     s.field( "data_files", self.data_files, default=[], doc="Files to use by detector type"),
     // DPDK
     s.field( "dpdk_eal_args", types.string, default="", doc='Args passed to the EAL in DPDK'),
+    s.field( "dpdk_enable_callback_bypass", types.flag, default=false, doc='Enable callback bypass'),
     s.field( "dpdk_iface_config", nicreader_cfg.InterfaceParameters, default=nicreader_cfg.InterfaceParameters, doc="Configuration of DPDK interface"),
     s.field( "dpdk_lcores_config", self.dpdk_lcore_config, default=self.dpdk_lcore_config, doc='Configuration of DPDK LCore IDs'),
     // FLX


### PR DESCRIPTION
In order to simplify dpdk interfaces optimisations in performance tests or when running the detector, the dpdk interface configuration parameters are now exposed as readout_gen parameters.