### PR TITLE
Fake hsi split 

### DIFF
--- a/scripts/fddaqconf_gen
+++ b/scripts/fddaqconf_gen
@@ -439,7 +439,6 @@ def cli(
         use_hsi_input=hsi.use_timing_hsi,
         use_fake_hsi_input=hsi.use_fake_hsi,
         use_ctb_input=ctb_hsi.use_ctb_hsi,
-        fake_hsi_to_dts=hsi.fake_hsi_to_dts,
         fake_hsi_to_ctb=hsi.fake_hsi_to_ctb,
         DEBUG=debug)
 

--- a/scripts/fddaqconf_gen
+++ b/scripts/fddaqconf_gen
@@ -439,6 +439,8 @@ def cli(
         use_hsi_input=hsi.use_timing_hsi,
         use_fake_hsi_input=hsi.use_fake_hsi,
         use_ctb_input=ctb_hsi.use_ctb_hsi,
+        fake_hsi_to_dts=hsi.fake_hsi_to_dts,
+        fake_hsi_to_ctb=hsi.fake_hsi_to_ctb,
         DEBUG=debug)
 
     #--------------------------------------------------------------------------


### PR DESCRIPTION
Allows sending fake HSI signals to CTB trigger modules (testing).
More details in: https://github.com/DUNE-DAQ/daqconf/pull/449
