### PR TITLE
Adding support for CIB

### DIFF
--- a/schema/fddaqconf/confgen.jsonnet
+++ b/schema/fddaqconf/confgen.jsonnet
@@ -81,15 +81,21 @@ local cs = {
   ]),
 
 
-	// need to make heads and tails of this
-	// The CIB only has one trigger type
+  cib_hsi_inst: s.record("cib_hsi_inst",[
+  	s.field("trigger"	,types.int4, default=0, 					doc='Which CIB trigger is mapped by this instance'),
+  	s.field("host" 	 	,types.host, default='localhost',			doc='Host where this HSI app instance will run'),
+  	s.field("cib_host"	,types.host, default="np04-iols-cib-01", 	doc='CIB endpoint host'),
+  	s.field("cib_port"	,types.port, default=8992, 					doc='CIB endpoint port'),  	
+  ]),
+  
+  // the number of entries on this sequence should match the number of instances for the laser system
+  cib_seq : s.sequence("cib_hsi_instances",	self.cib_hsi_inst, doc="list of CIB HSI instances"),
+  
   cib_hsi: s.record("cib_hsi", [
     # cib module options
-    s.field( "use_cib_hsi", types.flag, default=false, doc='Flag to control whether CIB HSI config is generated. Default is false'),
-    s.field( "cib_num_modules", types.int4, default=2, doc='Number of modules to be instantiated. Default is 2'),
-    s.field( "cib_hsi_host", cibmodules.host, default='localhost', doc='Host to run the HSI app on')
-    s.field( "cib_hsi_port", types.host, default='localhost', doc='Host to run the HSI app on')
-
+    s.field( "use_cib_hsi", 	types.flag, default=false, doc='Flag to control whether CIB HSI config is generated. Default is false'),	
+    s.field( "cib_num_modules", types.int4, default=1, doc='Number of modules to be instantiated. Default is 2 (one per periscope)'),
+	s.field( "cib_instances",	self.cib_seq , default=[self.cib_hsi_inst], doc="List of configurations for each instance"),
   ]),
 
 

--- a/schema/fddaqconf/confgen.jsonnet
+++ b/schema/fddaqconf/confgen.jsonnet
@@ -10,6 +10,9 @@ local types = moo.oschema.hier(stypes).dunedaq.daqconf.types;
 local sctb = import "ctbmodules/ctbmodule.jsonnet";
 local ctbmodule = moo.oschema.hier(sctb).dunedaq.ctbmodules.ctbmodule;
 
+local scib = import "cibmodules/cibmodule.jsonnet";
+local cibmodule = moo.oschema.hier(scib).dunedaq.cibmodules.cibmodule;
+
 local sboot = import "daqconf/bootgen.jsonnet";
 local bootgen = moo.oschema.hier(sboot).dunedaq.daqconf.bootgen;
 
@@ -78,6 +81,18 @@ local cs = {
   ]),
 
 
+	// need to make heads and tails of this
+	// The CIB only has one trigger type
+  cib_hsi: s.record("cib_hsi", [
+    # cib module options
+    s.field( "use_cib_hsi", types.flag, default=false, doc='Flag to control whether CIB HSI config is generated. Default is false'),
+    s.field( "cib_num_modules", types.int4, default=2, doc='Number of modules to be instantiated. Default is 2'),
+    s.field( "cib_hsi_host", cibmodules.host, default='localhost', doc='Host to run the HSI app on')
+    s.field( "cib_hsi_port", types.host, default='localhost', doc='Host to run the HSI app on')
+
+  ]),
+
+
   fddaqconf_gen: s.record('fddaqconf_gen', [
     s.field('detector',    detectorgen.detector,   default=detectorgen.detector,     doc='Boot parameters'),
     s.field('daq_common',  daqcommongen.daq_common, default=daqcommongen.daq_common,   doc='DAQ common parameters'),
@@ -85,6 +100,7 @@ local cs = {
     s.field('dataflow',    dataflowgen.dataflow,   default=dataflowgen.dataflow,     doc='Dataflow paramaters'),
     s.field('hsi',         hsigen.hsi,        default=hsigen.hsi,          doc='HSI parameters'),
     s.field('ctb_hsi',     self.ctb_hsi,    default=self.ctb_hsi,      doc='CTB parameters'),
+    s.field('cib_hsi',     self.cib_hsi,    default=self.cib_hsi,      doc='CIB parameters'),
     s.field('readout',     readoutgen.readout,    default=readoutgen.readout,      doc='Readout parameters'),
     s.field('timing',      timinggen.timing,     default=timinggen.timing,       doc='Timing parameters'),
     s.field('trigger',     triggergen.trigger,    default=triggergen.trigger,      doc='Trigger parameters')
@@ -93,4 +109,4 @@ local cs = {
 };
 
 // Output a topologically sorted array.
-stypes + sboot + sdetector + sdaqcommon + stiming + shsi + sreadout + strigger + sdataflow + sctb + moo.oschema.sort_select(cs)
+stypes + sboot + sdetector + sdaqcommon + stiming + shsi + sreadout + strigger + sdataflow + sctb + scib + moo.oschema.sort_select(cs)

--- a/scripts/fddaqconf_gen
+++ b/scripts/fddaqconf_gen
@@ -68,6 +68,9 @@ def expand_conf(config_data, debug=False):
     ctb_hsi = confgen.ctb_hsi(**config_data.ctb_hsi)
     if debug: console.log(f"ctb_hsi configuration object: {ctb_hsi.pod()}")
 
+    cib_hsi = confgen.cib_hsi(**config_data.cib_hsi)
+    if debug: console.log(f"cib_hsi configuration object: {cib_hsi.pod()}")
+
     readout = readoutgen.readout(**config_data.readout)
     if debug: console.log(f"readout configuration object: {readout.pod()}")
 
@@ -84,6 +87,7 @@ def expand_conf(config_data, debug=False):
         timing,
         hsi,
         ctb_hsi,
+        cib_hsi,
         readout,
         trigger,
         dataflow
@@ -222,6 +226,7 @@ def cli(
         timing,
         hsi,
         ctb_hsi,
+        cib_hsi,
         readout,
         trigger,
         dataflow
@@ -270,6 +275,8 @@ def cli(
     from daqconf.apps.fake_hsi_gen import get_fake_hsi_app
     console.log("Loading ctb config generator")
     from ctbmodules.apps.ctb_hsi_gen import get_ctb_hsi_app
+    console.log("Loading cib config generator")
+    from cibmodules.apps.cib_hsi_gen import get_cib_hsi_app
     console.log("Loading timing partition controller config generator")
     from daqconf.apps.tprtc_gen import get_tprtc_app
     console.log("Loading DPDK sender config generator")
@@ -305,7 +312,7 @@ def cli(
     #--------------------------------------------------------------------------
     # Generation starts here
     #--------------------------------------------------------------------------
-    console.log(f"Generating configs for hosts trigger={trigger.host_trigger} DFO={dataflow.host_dfo} dataflow={host_df} timing_hsi={hsi.host_timing_hsi} fake_hsi={hsi.host_fake_hsi} ctb_hsi={ctb_hsi.host_ctb_hsi}")
+    console.log(f"Generating configs for hosts trigger={trigger.host_trigger} DFO={dataflow.host_dfo} dataflow={host_df} timing_hsi={hsi.host_timing_hsi} fake_hsi={hsi.host_fake_hsi} ctb_hsi={ctb_hsi.host_ctb_hsi} cib_hsi={cib_hsi.host_cib_hsi}")
 
     the_system = System()
 
@@ -386,6 +393,22 @@ def cli(
         if debug: console.log("ctb hsi cmd data:", the_system.apps["ctbhsi"])
 
     #--------------------------------------------------------------------------
+    # CIB
+    #--------------------------------------------------------------------------
+    if cib_hsi.use_cib_hsi:
+        cib_source_id = sourceid_broker.get_next_source_id("HW_Signals_Interface")
+        sourceid_broker.register_source_id("HW_Signals_Interface", cib_source_id, None)
+
+        the_system.apps["cibhsi"] = get_cibmodules_app(
+            cib_hsi,
+            num_cibmodules = 2,
+            nickname = "cib",
+            source_id=cib_source_id,
+            )
+        if debug: console.log("cib hsi cmd data:", the_system.apps["cibhsi"])
+
+
+    #--------------------------------------------------------------------------
     # Real HSI
     #--------------------------------------------------------------------------
     if hsi.use_timing_hsi:
@@ -439,6 +462,7 @@ def cli(
         use_hsi_input=hsi.use_timing_hsi,
         use_fake_hsi_input=hsi.use_fake_hsi,
         use_ctb_input=ctb_hsi.use_ctb_hsi,
+        use_cib_input=cib_hsi.use_cib_hsi,
         DEBUG=debug)
 
     #--------------------------------------------------------------------------
@@ -648,6 +672,7 @@ def cli(
                 dataflow = dataflow,
                 hsi = hsi,
                 ctb_hsi = ctb_hsi,
+                cib_hsi = cib_hsi,
                 readout = readout,
                 timing = timing,
                 trigger = trigger,

--- a/scripts/fddaqconf_gen
+++ b/scripts/fddaqconf_gen
@@ -312,7 +312,8 @@ def cli(
     #--------------------------------------------------------------------------
     # Generation starts here
     #--------------------------------------------------------------------------
-    console.log(f"Generating configs for hosts trigger={trigger.host_trigger} DFO={dataflow.host_dfo} dataflow={host_df} timing_hsi={hsi.host_timing_hsi} fake_hsi={hsi.host_fake_hsi} ctb_hsi={ctb_hsi.host_ctb_hsi} cib_hsi={cib_hsi.host_cib_hsi}")
+    cib_hsi_hosts = [h["host"] for h in cib_hsi.cib_instances]
+    console.log(f"Generating configs for hosts trigger={trigger.host_trigger} DFO={dataflow.host_dfo} dataflow={host_df} timing_hsi={hsi.host_timing_hsi} fake_hsi={hsi.host_fake_hsi} ctb_hsi={ctb_hsi.host_ctb_hsi} cib_hsi={cib_hsi_hosts}")
 
     the_system = System()
 
@@ -399,13 +400,19 @@ def cli(
         cib_source_id = sourceid_broker.get_next_source_id("HW_Signals_Interface")
         sourceid_broker.register_source_id("HW_Signals_Interface", cib_source_id, None)
 
-        the_system.apps["cibhsi"] = get_cibmodules_app(
-            cib_hsi,
-            num_cibmodules = 2,
-            nickname = "cib",
-            source_id=cib_source_id,
-            )
-        if debug: console.log("cib hsi cmd data:", the_system.apps["cibhsi"])
+        for i in range(cib_hsi.cib_num_modules):
+          import dunedaq.fddaqconf.confgen as confgen
+          
+          cib_i_conf = confgen.cib_hsi_inst(cib_hsi.cib_instances[i])
+          
+          name = f"cibhsi{i}"
+          the_system.apps[name] = get_cib_hsi_app(
+                    "cib",
+                    i,
+                    cib_source_id,
+                    cib_i_conf,                    # this is the high level configuration as taken from fddaq/confgen.jsonnet
+                    )
+          if debug: console.log("cib hsi cmd data:", the_system.apps[name])
 
 
     #--------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds the CIB as a new HSI-like TC producer. The configuration consists of the number of instances to run (that depends on the number of lasers to be operated at the same time) and the connection details of the module, since the hardware and the readout modules need to be able to communicate. 

By default the CIB is off.

edit: tested this change (along with the remaining CIB related code) with `minimal_system_quick_test.py` and no issues were reported.